### PR TITLE
OPML without a title doesn't crash BePodder

### DIFF
--- a/sources-experimental/OPMLParser.cpp
+++ b/sources-experimental/OPMLParser.cpp
@@ -32,7 +32,8 @@ OPMLParser::Parse(BString filename){
 	 };
 	 
 	 //LOG("OPMLParser", liDebug ,"OPML title: %s",XML_GET_CONTENT(itemNode->nodesetval->nodeTab[0]->children));
-	 BString opml_name((const char*)XML_GET_CONTENT(itemNode->nodesetval->nodeTab[0]->children));
+	 const char* title = (const char*)XML_GET_CONTENT(itemNode->nodesetval->nodeTab[0]->children);
+	 BString opml_name(title != NULL ? title : "");
 	 
 	 
 	 

--- a/sources/Makefile
+++ b/sources/Makefile
@@ -174,7 +174,7 @@ SYMBOLS :=
 
 #	Includes debug information, which allows the binary to be debugged easily.
 #	If set to "TRUE", debug info will be created.
-DEBUGGER :=
+DEBUGGER := TRUE
 
 #	Specify any additional compiler flags to be used.
 COMPILER_FLAGS = -Wno-sign-compare -Wno-overloaded-virtual \


### PR DESCRIPTION
* Fixes #45
* The malformed lines are reported in the log