### PR TITLE
BePoder: fix warnings and errors reported by GCC 11.2.

### DIFF
--- a/library/libfish/RVActionGoto.h
+++ b/library/libfish/RVActionGoto.h
@@ -17,7 +17,7 @@ class RVActionGoto : public RVAction
 				//printf("goto : %s\n",param.String());
 			BMessage* msg=new BMessage('goto');
 			msg->AddString("goto",param);
-			BMessenger(hand).SendMessage(msg,hand);
+			return BMessenger(hand).SendMessage(msg,hand);
 		}
 		virtual	BString		GetDescription(){
 			return "Goto";

--- a/library/libfish/RVActionOpenURL.h
+++ b/library/libfish/RVActionOpenURL.h
@@ -16,7 +16,7 @@ class RVActionOpenURL : public RVAction
 		virtual 	status_t		Perform(BString param){
 				BMessage* msg=new BMessage('opur');
 				msg->AddString("url",param);
-				BMessenger(hand).SendMessage(msg,hand);
+				return BMessenger(hand).SendMessage(msg,hand);
 		}
 		
 		virtual	BString		GetDescription(){

--- a/sources-experimental/MainWindow.cpp
+++ b/sources-experimental/MainWindow.cpp
@@ -1232,7 +1232,7 @@ MainWindow::ShowItemDescription(MemoryArchive* archive){
 		
 		
 		off_t* len = 0;
-		if (archive->GetData(ITEM_ENCLOSURE_LENGTH,(const void**)&len)>0 && len>0){
+		if (archive->GetData(ITEM_ENCLOSURE_LENGTH,(const void**)&len)>0 && *len > 0) {
 			char sizeString[256];
 			bottom << " [" << string_for_size(*len, sizeString, sizeof(sizeString)) << "]";
 		}

--- a/sources-experimental/RunView/RunView.cpp
+++ b/sources-experimental/RunView/RunView.cpp
@@ -2563,7 +2563,7 @@ Line::CountChars (int16 pos, int16 len)
   if (pos + len > fLength)
     len = fLength - pos;
 
-  register int16 i = pos;
+  int16 i = pos;
   while (i < pos + len)
   {
     i += UTF8_CHAR_LEN(fText[i]);


### PR DESCRIPTION
Only warning remaining is:

"'-Wno-overloaded-virtual' is valid for C++/ObjC++ but not for C"

But I think that's pretty harmless.